### PR TITLE
fix: update Home and View Full Map button colors to match CTA styling…

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -502,25 +502,23 @@
         }
 
         .home-btn {
-            background: #52caec;
+            background: #2776de;
             color: white;
-            box-shadow: 0 2px 6px rgba(82, 202, 236, 0.3);
+            box-shadow: 0 2px 6px rgba(39, 118, 222, 0.3);
         }
-
         .home-btn:hover {
-            background: #3ba8cc;
+            background: #1a5fbf;
             transform: translateY(-2px);
-            box-shadow: 0 4px 10px rgba(82, 202, 236, 0.4);
+            box-shadow: 0 4px 10px rgba(39, 118, 222, 0.4);
         }
 
         .view-map {
             background: white;
-            color: #52caec;
-            border: 2px solid #52caec;
+            color: #2776de;
+            border: 2px solid #2776de;
         }
-
         .view-map:hover {
-            background: #52caec;
+            background: #2776de;
             color: white;
             transform: translateY(-2px);
         }


### PR DESCRIPTION
📌 Related Issue
Fixes #219

Description of Changes
Updated the Home and View Full Map button colors in public/index.html to match the primary CTA styling used across the site. Replaced the previous light blue (#52caec) with the primary blue (#2776de) for both background and border colors, including hover states.

Type of Change

 🎨 UI/UX or Design Update


📸 Screenshots 
before 
<img width="371" height="107" alt="image" src="https://github.com/user-attachments/assets/1693930a-9c19-46a0-a133-7988ac518a99" />

after 
<img width="371" height="107" alt="image" src="https://github.com/user-attachments/assets/da8c747c-cb79-47b8-ac49-6fc765344e30" />



✅ Checklist

 I've read the CONTRIBUTING.md guidelines.
 My code follows the project's conventions.
 I've linked the related issue correctly.
 I've tested my changes locally.
 I've added or updated documentation/comments if needed.
 My PR title follows the branch & commit naming conventions.
 My changes introduce no new warnings or errors.
 I've performed a self-review of my work.