### PR TITLE
fix: redesign Evacuation Safety page to match SafeHaven theme (#239)

### DIFF
--- a/public/4.EvacuationSafety/EvacuationSafety.html
+++ b/public/4.EvacuationSafety/EvacuationSafety.html
@@ -11,64 +11,88 @@
   <!-- Font Awesome for icons -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
   <style>
+    * { box-sizing: border-box; }
     body {
       font-family: 'Poppins', sans-serif;
-      background: #f4f4f4;
+      background: #f3f4f6;
       margin: 0;
       padding: 0;
       color: #333;
     }
     header {
-      background: linear-gradient(90deg, #d32f2f, #b71c1c);
-      padding: 1.5rem;
+      background: linear-gradient(90deg, #4467b1, #3f5ea3);
+      padding: 24px 24px;
       color: #fff;
+      display: flex; 
+      align-items: center; 
+      justify-content: center;
+      gap: 15px;
+      font-size: 1.4rem;
+      font-weight: 600;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+      position: sticky;
+      top: 0;
+      z-index: 1000;
+    }
+    header a {
+      display: flex;
+      margin-right: auto;
+    }
+    header img {
+      height: 40px; 
+      width: auto; 
+      border-radius: 6px;
+      display: block;
+    }
+    header span {
+      flex-grow: 1;
       text-align: center;
-      font-size: 2rem;
-      font-weight: bold;
+      margin-right: 40px;
+      font-size: 1.4rem;
+      font-weight: 600;
+    }
+    .main-content {
+      max-width: 1000px;
+      margin: 0 auto;
+      padding: 20px 16px 40px;
     }
     .alert-banner {
-      background: #ff5252;
+      background: #dc3545;
       color: #fff;
-      padding: 1rem;
+      padding: 12px 16px;
       text-align: center;
-      font-size: 1.5rem;
-      font-weight: bold;
-      margin: 1rem;
-      border-radius: 8px;
-      box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+      font-size: 1rem;
+      font-weight: 600;
+      margin: 0 0 12px;
+      border-radius: 10px;
+      box-shadow: 0 2px 8px rgba(220,53,69,0.25);
     }
     .datetime {
       text-align: center;
-      font-size: 1.2rem;
-      margin-bottom: 1rem;
+      font-size: 0.9rem;
+      color: #666;
+      margin-bottom: 16px;
     }
-    /* Map container with embedded map and overlay */
-    .map-container {
-      width: 90%;
-      height: 400px;
-      margin: 1rem auto;
-      border-radius: 8px;
-      overflow: hidden;
-      box-shadow: 0 4px 8px rgba(0,0,0,0.2);
-      position: relative;
-    }
-    /* Map Heading */
     .map-heading {
-      text-align: center;
-      font-size: 1.8rem;
-      margin: 1rem auto 0;
-      color: #d32f2f;
+      font-size: 1.1rem;
+      margin: 0 0 10px;
+      color: #2776de;
+      font-weight: 600;
+    }
+    .map-container {
+      width: 100%;
+      height: 280px;
+      margin: 0 0 24px;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 4px 14px rgba(0,0,0,0.1);
+      position: relative;
     }
     .map-container iframe {
       width: 100%;
       height: 100%;
       border: 0;
-      transition: transform 0.3s ease;
     }
-    .map-container iframe:hover {
-      transform: scale(1.02);
-    }
-    /* Transparent overlay to capture clicks */
     .map-overlay {
       position: absolute;
       top: 0;
@@ -79,169 +103,264 @@
       background: transparent;
       z-index: 2;
     }
-    /* Safe zones list */
-    .safe-zones {
-      width: 90%;
-      margin: 1rem auto;
-    }
     .safe-zones h2 {
+      font-size: 1.1rem;
+      margin: 0 0 12px;
+      color: #2776de;
+      font-weight: 600;
       text-align: center;
-      margin-bottom: 1rem;
-      color: #d32f2f;
     }
+
+    /* Two-column grid for safe zone cards */
+    .safe-zone-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 12px;
+    }
+
     .safe-zone-item {
       background: #fff;
-      padding: 1rem;
-      margin-bottom: 1rem;
-      border-radius: 8px;
+      padding: 14px 16px;
+      border-radius: 10px;
       display: flex;
       align-items: center;
-      justify-content: space-between;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+      gap: 12px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+      border-left: 4px solid #2776de;
+      cursor: pointer;
+      transition: transform 0.2s ease;
     }
+    .safe-zone-item:hover {
+      transform: translateY(-2px);
+    }
+
+    /* Numbered circular badge */
+    .zone-badge {
+      width: 32px;
+      height: 32px;
+      flex-shrink: 0;
+      border-radius: 50%;
+      background: #2776de;
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      font-size: 0.95rem;
+    }
+
+    /* Different accent colors per badge, like the reference */
+    .safe-zone-item:nth-child(1) .zone-badge { background: #dc3545; }
+    .safe-zone-item:nth-child(1) { border-left-color: #dc3545; }
+    .safe-zone-item:nth-child(2) .zone-badge { background: #2776de; }
+    .safe-zone-item:nth-child(3) .zone-badge { background: #2776de; }
+    .safe-zone-item:nth-child(4) .zone-badge { background: #17a2b8; }
+    .safe-zone-item:nth-child(5) .zone-badge { background: #17a2b8; }
+
     .safe-zone-details {
       display: flex;
       flex-direction: column;
+      gap: 4px;
+      flex-grow: 1;
+      min-width: 0;
     }
-    .safe-zone-details span {
-      margin-bottom: 0.3rem;
+    .safe-zone-details .distance {
+      font-weight: 600;
+      color: #2776de;
+      font-size: 0.9rem;
+    }
+    .safe-zone-details .address {
+      font-size: 0.82rem;
+      color: #666;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
     .go-button {
-      background: #43a047;
+      background: #2776de;
       color: #fff;
-      padding: 0.5rem 1rem;
+      padding: 7px 14px;
       border: none;
       border-radius: 50px;
       cursor: pointer;
-      font-size: 1rem;
-      transition: background 0.3s ease;
+      font-size: 0.8rem;
+      font-weight: 500;
+      transition: background 0.2s ease;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 5px;
+      flex-shrink: 0;
     }
     .go-button:hover {
-      background: #388e3c;
+      background: #1a5fbf;
     }
-    /* Evacuation note */
+
+    /* Closest Safe Zone highlight box */
+    .closest-zone-box {
+      grid-column: 1 / -1;
+      background: #eaf2ff;
+      border-radius: 10px;
+      padding: 16px;
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+    }
+    .closest-zone-box .icon {
+      width: 38px;
+      height: 38px;
+      flex-shrink: 0;
+      border-radius: 50%;
+      background: #2776de;
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1rem;
+    }
+    .closest-zone-box .text strong {
+      display: block;
+      color: #2776de;
+      font-size: 0.95rem;
+      margin-bottom: 4px;
+    }
+    .closest-zone-box .text span {
+      font-size: 0.85rem;
+      color: #555;
+    }
+
     .evacuation-note {
-      width: 90%;
-      margin: 1rem auto;
-      padding: 1rem;
+      margin: 20px 0 0;
+      padding: 14px 16px;
       background: #fff3e0;
-      border-left: 5px solid #ff6f00;
-      border-radius: 4px;
-      font-size: 1.1rem;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-    }
-    /* Custom alert box */
-    .custom-alert {
-      background: #ff5252;
-      color: white;
-      padding: 10px;
+      border-left: 4px solid #ff9800;
       border-radius: 8px;
-      margin: 20px auto;
-      width: 80%;
-      font-size: 1.2rem;
-      font-weight: bold;
+      font-size: 0.9rem;
+      color: #555;
+    }
+    .custom-alert {
+      background: #2776de;
+      color: white;
+      padding: 12px 16px;
+      border-radius: 10px;
+      margin: 16px 0 0;
+      font-size: 0.95rem;
+      font-weight: 500;
       text-align: center;
+    }
+    @media (max-width: 600px) {
+      header { font-size: 1.15rem; padding: 14px 16px; }
+      .map-container { height: 220px; }
+      .safe-zone-grid { grid-template-columns: 1fr; }
+      .safe-zone-item { flex-direction: row; }
     }
   </style>
 </head>
 <body>
-  <header>Evacuation & Safety Dashboard</header>
-  
-  <div class="alert-banner">
-    FLOOD ALERT: EVACUATE IMMEDIATELY!
-  </div>
-  
-  <div class="datetime">
-    <span id="date"></span> | <span id="time"></span>
-  </div>
-  
-  <!-- Map Heading -->
-  <h2 class="map-heading">Evacuation Route</h2>
-  
-  <!-- Map Container with Embedded Map and Clickable Overlay -->
-  <div class="map-container">
-    <iframe id="mapFrame" src=""></iframe>
-    <div class="map-overlay" id="mapOverlay"></div>
-  </div>
-  
-  <!-- Nearest Safe Zones List -->
-  <div class="safe-zones">
-    <h2>Nearest Safe Zones</h2>
-    
-    <!-- Safe Zone 1 -->
-    <div class="safe-zone-item" onclick="updateMap('35.6895,139.6917', '1.2 km', '1-1 Udagawacho, Shibuya City, Tokyo, Japan')">
-      <div class="safe-zone-details">
-        <span><strong>Distance:</strong> 1.2 km</span>
-        <span><strong>Address:</strong> 1-1 Udagawacho, Shibuya City, Tokyo, Japan</span>
-      </div>
-      <button class="go-button"><i class="fas fa-location-arrow"></i> Go!</button>
+  <header>
+    <a href="index.html" aria-label="Safe Haven home">
+      <img src="https://i.pinimg.com/474x/f4/79/4a/f4794a6bc83c46af8a4f287d45dc5f6f.jpg" alt="Safe Haven Logo">
+    </a>
+    <span>Evacuation & Safety Dashboard</span>
+  </header>
+
+  <div class="main-content">
+    <div class="alert-banner">
+      FLOOD ALERT: EVACUATE IMMEDIATELY!
     </div>
 
-    <!-- Safe Zone 2 -->
-    <div class="safe-zone-item" onclick="updateMap('35.6762,139.6503', '2.5 km', '3-2 Aoyama, Minato City, Tokyo, Japan')">
-      <div class="safe-zone-details">
-        <span><strong>Distance:</strong> 2.5 km</span>
-        <span><strong>Address:</strong> 3-2 Aoyama, Minato City, Tokyo, Japan</span>
-      </div>
-      <button class="go-button"><i class="fas fa-location-arrow"></i> Go!</button>
+    <div class="datetime">
+      <span id="date"></span> | <span id="time"></span>
     </div>
 
-    <!-- Safe Zone 3 -->
-    <div class="safe-zone-item" onclick="updateMap('35.6696,139.7312', '3.0 km', '5-4 Roppongi, Minato City, Tokyo, Japan')">
-      <div class="safe-zone-details">
-        <span><strong>Distance:</strong> 3.0 km</span>
-        <span><strong>Address:</strong> 5-4 Roppongi, Minato City, Tokyo, Japan</span>
-      </div>
-      <button class="go-button"><i class="fas fa-location-arrow"></i> Go!</button>
+    <h2 class="map-heading">Evacuation Route</h2>
+
+    <div class="map-container">
+      <iframe id="mapFrame" src=""></iframe>
+      <div class="map-overlay" id="mapOverlay"></div>
     </div>
 
-    <!-- Safe Zone 4 -->
-    <div class="safe-zone-item" onclick="updateMap('35.6197,139.7817', '4.0 km', '6-1 Odaiba, Koto City, Tokyo, Japan')">
-      <div class="safe-zone-details">
-        <span><strong>Distance:</strong> 4.0 km</span>
-        <span><strong>Address:</strong> 6-1 Odaiba, Koto City, Tokyo, Japan</span>
+    <div class="safe-zones">
+      <h2>Nearest Safe Zones</h2>
+
+      <div class="safe-zone-grid">
+        <div class="safe-zone-item" onclick="updateMap('28.6129,77.2295', '1.2 km', 'Pragati Maidan Relief Center, New Delhi')">
+          <div class="zone-badge">1</div>
+          <div class="safe-zone-details">
+            <span class="distance">Distance: 1.2 km</span>
+            <span class="address">Pragati Maidan Relief Center, New Delhi</span>
+          </div>
+          <button class="go-button"><i class="fas fa-location-arrow"></i> Go!</button>
+        </div>
+
+        <div class="safe-zone-item" onclick="updateMap('28.6315,77.2167', '2.5 km', 'Connaught Place Community Center, New Delhi')">
+          <div class="zone-badge">2</div>
+          <div class="safe-zone-details">
+            <span class="distance">Distance: 2.5 km</span>
+            <span class="address">Connaught Place Community Center, New Delhi</span>
+          </div>
+          <button class="go-button"><i class="fas fa-location-arrow"></i> Go!</button>
+        </div>
+
+        <div class="safe-zone-item" onclick="updateMap('28.5894,77.2284', '3.0 km', 'Lodhi Road Emergency Shelter, New Delhi')">
+          <div class="zone-badge">3</div>
+          <div class="safe-zone-details">
+            <span class="distance">Distance: 3.0 km</span>
+            <span class="address">Lodhi Road Emergency Shelter, New Delhi</span>
+          </div>
+          <button class="go-button"><i class="fas fa-location-arrow"></i> Go!</button>
+        </div>
+
+        <div class="safe-zone-item" onclick="updateMap('28.6139,77.1925', '4.0 km', 'Talkatora Stadium Relief Camp, New Delhi')">
+          <div class="zone-badge">4</div>
+          <div class="safe-zone-details">
+            <span class="distance">Distance: 4.0 km</span>
+            <span class="address">Talkatora Stadium Relief Camp, New Delhi</span>
+          </div>
+          <button class="go-button"><i class="fas fa-location-arrow"></i> Go!</button>
+        </div>
+
+        <div class="safe-zone-item" onclick="updateMap('28.6280,77.2426', '5.2 km', 'Thyagraj Community Shelter, New Delhi')">
+          <div class="zone-badge">5</div>
+          <div class="safe-zone-details">
+            <span class="distance">Distance: 5.2 km</span>
+            <span class="address">Thyagraj Community Shelter, New Delhi</span>
+          </div>
+          <button class="go-button"><i class="fas fa-location-arrow"></i> Go!</button>
+        </div>
+
+        <div class="closest-zone-box">
+          <div class="icon"><i class="fa-solid fa-location-dot"></i></div>
+          <div class="text">
+            <strong>Closest Safe Zone &middot; Distance: 1.2 km &middot; Time: 6 min</strong>
+            <span>Pragati Maidan Relief Center, New Delhi</span>
+          </div>
+        </div>
       </div>
-      <button class="go-button"><i class="fas fa-location-arrow"></i> Go!</button>
     </div>
 
-    <!-- Safe Zone 5 -->
-    <div class="safe-zone-item" onclick="updateMap('35.6727,139.7401', '5.2 km', '7-2 Akasaka, Minato City, Tokyo, Japan')">
-      <div class="safe-zone-details">
-        <span><strong>Distance:</strong> 5.2 km</span>
-        <span><strong>Address:</strong> 7-2 Akasaka, Minato City, Tokyo, Japan</span>
-      </div>
-      <button class="go-button"><i class="fas fa-location-arrow"></i> Go!</button>
+    <div class="evacuation-note">
+      <strong>Evacuation Notice:</strong> Please evacuate your area within the next 30 minutes. Follow the highlighted evacuation route to reach the nearest safe zone. Stay calm and proceed immediately.
     </div>
+
+    <div id="customAlert" class="custom-alert" style="display: none;"></div>
   </div>
 
-  <!-- Evacuation Note -->
-  <div class="evacuation-note">
-    <strong>Evacuation Notice:</strong> Please evacuate your area within the next 30 minutes. Follow the highlighted evacuation route to reach the nearest safe zone. Stay calm and proceed immediately.
-  </div>
-  
-  <!-- Custom Alert Box -->
-  <div id="customAlert" class="custom-alert" style="display: none;"></div>
-  
   <script>
-    // Display current date and time in JST (Japan Standard Time)
     function updateDateTime() {
       const now = new Date();
       const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
-      const timeOptions = { hour: '2-digit', minute: '2-digit', second: '2-digit', timeZone: 'Asia/Tokyo' };
+      const timeOptions = { hour: '2-digit', minute: '2-digit', second: '2-digit', timeZone: 'Asia/Kolkata' };
       document.getElementById("date").textContent = now.toLocaleDateString('en-US', options);
       document.getElementById("time").textContent = now.toLocaleTimeString('en-US', timeOptions);
     }
     setInterval(updateDateTime, 1000);
     updateDateTime();
-    
-    // Function to update the map and details for each safe zone
+
     function updateMap(coordinates, distance, address) {
-      const baseUrl = "https://maps.google.com/maps?f=d&hl=en&geocode=&saddr=35.6895,139.6917&daddr=" + coordinates + "&dirflg=d&output=embed";
+      const baseUrl = "https://maps.google.com/maps?f=d&hl=en&geocode=&saddr=28.6139,77.2090&daddr=" + coordinates + "&dirflg=d&output=embed";
       document.getElementById("mapFrame").src = baseUrl;
-      
+
       const safeZoneDetails = `
         <strong>Distance:</strong> ${distance}<br>
         <strong>Address:</strong> ${address}


### PR DESCRIPTION
Closes #239

## Description of Changes
- Redesigned page to match SafeHaven's blue theme (#2776de) instead of red Tokyo-style theme
- Replaced all placeholder Tokyo, Japan locations with India-specific locations 
  (Pragati Maidan, Connaught Place, Lodhi Road, Talkatora Stadium, Thyagraj Shelter)
- Updated timezone display from JST to IST
- Reduced excessive whitespace with a centered, compact container (max-width: 1000px)
- Replaced flat address list with card-based safe zone display, numbered circular badges, 
  and color-coded accents
- Added a two-column responsive grid for safe zone cards (collapses to single column on mobile)
- Added a "Closest Safe Zone" highlight box for better visual hierarchy
- Added sticky navbar with SafeHaven logo matching the rest of the site
- Improved typography, spacing, and overall visual hierarchy
- Page remains fully responsive on mobile and desktop

## Type of Change
- [x] 🎨 UI/UX or Design Update

##Screenshot

**before**
<img width="826" height="816" alt="image" src="https://github.com/user-attachments/assets/6d63aeb4-11e5-4677-ab3d-17542dda39b8" />

after
<img width="989" height="822" alt="image" src="https://github.com/user-attachments/assets/31ee8cde-d592-496e-a48e-6ce6490c6ac9" />


## Files Changed
- `public/4.EvacuationSafety/EvacuationSafety.html`

## ✅ Checklist
- [x] I've read the CONTRIBUTING.md guidelines.
- [x] My code follows the project's conventions.
- [x] I've linked the related issue correctly.
- [x] I've tested my changes locally.
- [x] My PR title follows the branch & commit naming conventions.
- [x] My changes introduce no new warnings or errors.
- [x] I've performed a self-review of my work.

