### PR TITLE
feat: convert hamburger menu to horizontal nav links on desktop view

### DIFF
--- a/public/components/navbar.css
+++ b/public/components/navbar.css
@@ -68,6 +68,10 @@
     z-index: 1;
 }
 
+.sh-navbar__desktop-right {
+    display: none;
+}
+
 .sh-navbar__logo-link {
     display: inline-flex;
     text-decoration: none;
@@ -214,7 +218,7 @@
     display: flex;
     justify-content: center;
     gap: 20px;
-    
+
     padding: 10px 24px 12px;
     background: #fff;
     border-top: 1px solid rgba(0, 0, 0, 0.04);
@@ -251,6 +255,65 @@
 @media (max-width: 1024px) {
     .sh-navbar--has-status .sh-navbar__status--mobile {
         display: flex;
+    }
+}
+
+/* desktop (>=1025px): show horizontal nav links inline in same row, hide hamburger toggle */
+@media (min-width: 1025px) {
+    .sh-navbar__toggle {
+        display: none;
+    }
+
+    .sh-navbar {
+        display: flex;
+        align-items: center;
+        flex-wrap: nowrap;
+    }
+
+    .sh-navbar__main {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        padding: 12px 0 12px 20px;
+        flex-shrink: 0;
+    }
+
+    .sh-navbar__left {
+        flex-shrink: 0;
+    }
+
+    .sh-navbar__center {
+        flex-shrink: 0;
+    }
+
+    .sh-navbar__center h1 {
+        font-size: 1.3rem;
+        white-space: nowrap;
+    }
+
+    .sh-navbar__right {
+        display: none;
+    }
+
+    .sh-navbar__desktop-links {
+        display: flex;
+        flex-wrap: nowrap;
+        justify-content: center;
+        align-items: center;
+        padding: 0 12px;
+        flex: 1;
+        min-width: 0;
+    }
+
+    .sh-navbar__desktop-right {
+        display: flex;
+        align-items: center;
+        flex-shrink: 0;
+        padding-right: 20px;
+    }
+
+    .sh-navbar__mobile-links {
+        display: none !important;
     }
 }
 

--- a/public/components/navbar.js
+++ b/public/components/navbar.js
@@ -112,6 +112,13 @@
         nav.appendChild(linkList(LINKS, r, cur, false));
         nav.appendChild(linkList(LINKS, r, cur, true));
 
+        var desktopRight = document.createElement('div');
+        desktopRight.className = 'sh-navbar__desktop-right';
+        desktopRight.innerHTML =
+            '<a href="' + r + '10.Auth/Login.html" class="sh-navbar__profile" aria-label="Profile">' +
+            '<i class="far fa-user-circle"></i></a>';
+        nav.appendChild(desktopRight);
+
         if (c.showStatus) {
             var sd = document.createElement('div');
             sd.className = 'sh-navbar__status sh-navbar__status--desktop';
@@ -168,3 +175,4 @@
     if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
     else init();
 })();
+


### PR DESCRIPTION
# Pull Request — SafeHaven

Thank you for contributing to **🛡️ SafeHaven: A Crowdsourced Disaster Management Platform**!  
Please fill out the following details to help us review your PR efficiently.

---

## 📌 Related Issue
Fixes #250

---

## Description of Changes
Converted the hamburger menu to horizontal nav links on desktop view. Previously, navigation links were only accessible via the hamburger icon even on large screens (≥1024px), adding unnecessary friction for desktop users.

Changes made in `components/navbar.css` and `components/navbar.js`:
- On desktop (≥1025px), the hamburger toggle is now hidden and all nav links display inline as a horizontal bar in the header.
- Added a separate `.sh-navbar__desktop-right` profile icon wrapper so that logo, title, nav links, and profile icon all sit in a single row on desktop.
- Mobile/tablet (≤1024px) behavior is completely unchanged — hamburger icon and dropdown menu work exactly as before.

No new links or routes were added; this is purely a responsive display change using CSS media queries, as requested in the issue.

---

## Type of Change
- [ ] 🐛 Bug Fix  
- [x] 🔧 Feature Modification  
- [ ] ✨ New Feature  
- [ ] 🧹 Maintenance / Cleanup / Documentation Update  
- [x] 🎨 UI/UX or Design Update  
- [ ] 📘 Resource / Content Addition  
- [ ] Other  

---

## 📸 Screenshots / Video
<img width="1896" height="911" alt="image" src="https://github.com/user-attachments/assets/a27aff95-ed50-4299-8005-dd2033b3282d" />

---

## ✅ Checklist
- [ ] I've read the **CONTRIBUTING.md** guidelines.  
- [x] My code follows the project's conventions.  
- [x] I've linked the related issue correctly.  
- [x] I've tested my changes locally.  
- [ ] I've added or updated documentation/comments if needed.  
- [x] My PR title follows the branch & commit naming conventions.  
- [x] My changes introduce no new warnings or errors.  
- [x] I've performed a self-review of my work.  

---

## 💬 Additional Notes (Optional)
Tested across desktop (≥1025px) and mobile/tablet (≤1024px) breakpoints. Desktop now shows logo, title, nav links, and profile icon in a single row; mobile retains the original hamburger + dropdown behavior unchanged.