### PR TITLE
fix(routes): resolve broken signup page route

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,9 +1,14 @@
 import express from 'express';
 import OpenAI from 'openai';
 import cors from 'cors';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
 
 dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const app = express();
 
@@ -15,6 +20,14 @@ app.use(express.json());
 
 // Serve static files from public directory
 app.use(express.static('public'));
+
+app.get('/signup', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', '10.Auth', 'SignUp.html'));
+});
+
+app.get('/login', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', '10.Auth', 'Login.html'));
+});
 
 // OpenAI client
 let openai;

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,8 @@
     { "src": "public/**/*", "use": "@vercel/static" }
   ],
   "routes": [
+    { "src": "/signup", "dest": "public/10.Auth/SignUp.html" },
+    { "src": "/login", "dest": "public/10.Auth/Login.html" },
     { "src": "/(.*)", "dest": "public/$1" }
   ]
 }


### PR DESCRIPTION
## Summary
This PR fixes the broken signup page route by explicitly mapping the `/signup` path to the existing auth page file.

## Problem
The signup page exists at `public/10.Auth/SignUp.html`, but the application did not expose a clean `/signup` route. As a result, visiting `/signup` returned a 404 because the request was not mapped to the correct static HTML file.

## Changes made
- Added a dedicated `/signup` route for local development in `server.js`
- Added a dedicated `/login` route for consistency with the auth pages
- Updated `vercel.json` to map:
  - `/signup` → `public/10.Auth/SignUp.html`
  - `/login` → `public/10.Auth/Login.html`
- Kept the existing static fallback route for other public assets/pages

## Files changed
- `server.js`
- `vercel.json`

## Why this fixes the issue
The signup page already existed, but the route `/signup` was not explicitly connected to it. This PR adds the missing route mapping for both local development and deployment so that the signup page resolves correctly instead of returning 404.

## Testing
- Verified `/signup` resolves to the signup page in local development
- Verified `/login` resolves correctly as well
- Verified Vercel routing maps clean auth routes to the correct HTML files
- Confirmed existing static routes continue to work as expected

Closes #294